### PR TITLE
Renaming packages

### DIFF
--- a/sleep/build.gradle
+++ b/sleep/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/SleepLogController.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/SleepLogController.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.controller;
 
 import com.noom.interview.fullstack.sleep.controller.dto.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.usecase.*;
 import lombok.*;
 import org.jetbrains.annotations.*;

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/AddSleepLogRequest.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/AddSleepLogRequest.java
@@ -1,9 +1,10 @@
 package com.noom.interview.fullstack.sleep.controller.dto;
 
 import com.fasterxml.jackson.annotation.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import lombok.*;
 
+import javax.validation.constraints.*;
 import java.time.*;
 
 @Data
@@ -14,10 +15,15 @@ public class AddSleepLogRequest {
 
     @JsonFormat(pattern = "MM/dd/yyyy")
     private LocalDate sleepDate;
+
     @JsonFormat(pattern = "HH:mm")
+    @NotNull(message = "sleepStart is required")
     private LocalTime sleepStart;
 
     @JsonFormat(pattern = "HH:mm")
+    @NotNull(message = "sleepStart is required")
     private LocalTime sleepEnd;
+
+    @NotNull(message = "sleepStart is required")
     private SleepQuality sleepQuality;
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/AvgSleepLogResponse.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/AvgSleepLogResponse.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.controller.dto;
 
 import com.fasterxml.jackson.annotation.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import lombok.*;
 
 import java.time.*;

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/SleepLogResponse.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/controller/dto/SleepLogResponse.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.controller.dto;
 
 import com.fasterxml.jackson.annotation.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import lombok.*;
 
 import java.time.*;

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProvider.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProvider.java
@@ -1,6 +1,6 @@
 package com.noom.interview.fullstack.sleep.db;
 
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 
 import java.time.*;
 import java.util.*;

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProviderImpl.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProviderImpl.java
@@ -1,8 +1,8 @@
 package com.noom.interview.fullstack.sleep.db;
 
-import com.noom.interview.fullstack.sleep.db.datamapper.*;
+import com.noom.interview.fullstack.sleep.db.entity.*;
 import com.noom.interview.fullstack.sleep.db.repository.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import lombok.*;
 import org.springframework.stereotype.*;
 
@@ -18,7 +18,7 @@ public class DailySleepLogProviderImpl implements DailySleepLogProvider {
 
     @Override
     public DailySleepLog save(DailySleepLog dailySleepLog) {
-        DailySleepLogDataMapper data = repository.save(toDataMapper(dailySleepLog));
+        DailySleepLogEntity data = repository.save(toDataMapper(dailySleepLog));
 
         dailySleepLog.setId(data.getId());
         return dailySleepLog;
@@ -26,14 +26,14 @@ public class DailySleepLogProviderImpl implements DailySleepLogProvider {
 
     @Override
     public List<DailySleepLog> findByUserIdAndInterval(Long userId, LocalDateTime start, LocalDateTime end) {
-        List<DailySleepLogDataMapper> result = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(userId,
+        List<DailySleepLogEntity> result = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(userId,
             start , end);
 
         return result.stream().map(this::toEntity).collect(Collectors.toList());
     }
 
-    private static DailySleepLogDataMapper toDataMapper(DailySleepLog dailySleepLog) {
-        return DailySleepLogDataMapper.builder()
+    private static DailySleepLogEntity toDataMapper(DailySleepLog dailySleepLog) {
+        return DailySleepLogEntity.builder()
             .userId(dailySleepLog.getUserId())
             .sleepStart(dailySleepLog.getSleepStart())
             .sleepEnd(dailySleepLog.getSleepEnd())
@@ -42,14 +42,14 @@ public class DailySleepLogProviderImpl implements DailySleepLogProvider {
             .build();
     }
 
-    private DailySleepLog toEntity(DailySleepLogDataMapper dailySleepLogDataMapper) {
+    private DailySleepLog toEntity(DailySleepLogEntity dailySleepLogEntity) {
         return DailySleepLog.builder()
-            .id(dailySleepLogDataMapper.getId())
-            .userId(dailySleepLogDataMapper.getUserId())
-            .sleepDuration(dailySleepLogDataMapper.getSleepDuration())
-            .sleepStart(dailySleepLogDataMapper.getSleepStart())
-            .sleepEnd(dailySleepLogDataMapper.getSleepEnd())
-            .sleepQuality(dailySleepLogDataMapper.getSleepQuality())
+            .id(dailySleepLogEntity.getId())
+            .userId(dailySleepLogEntity.getUserId())
+            .sleepDuration(dailySleepLogEntity.getSleepDuration())
+            .sleepStart(dailySleepLogEntity.getSleepStart())
+            .sleepEnd(dailySleepLogEntity.getSleepEnd())
+            .sleepQuality(dailySleepLogEntity.getSleepQuality())
             .build();
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/entity/DailySleepLogEntity.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/entity/DailySleepLogEntity.java
@@ -1,6 +1,6 @@
-package com.noom.interview.fullstack.sleep.db.datamapper;
+package com.noom.interview.fullstack.sleep.db.entity;
 
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import lombok.*;
 import org.springframework.data.annotation.*;
 
@@ -13,7 +13,7 @@ import java.time.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DailySleepLogDataMapper {
+public class DailySleepLogEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/repository/DailySleepLogRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/db/repository/DailySleepLogRepository.java
@@ -1,6 +1,6 @@
 package com.noom.interview.fullstack.sleep.db.repository;
 
-import com.noom.interview.fullstack.sleep.db.datamapper.*;
+import com.noom.interview.fullstack.sleep.db.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
@@ -8,7 +8,7 @@ import java.time.*;
 import java.util.*;
 
 @Repository
-public interface DailySleepLogRepository extends JpaRepository<DailySleepLogDataMapper, Long> {
+public interface DailySleepLogRepository extends JpaRepository<DailySleepLogEntity, Long> {
 
-    List<DailySleepLogDataMapper> findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(Long userId, LocalDateTime start, LocalDateTime end);
+    List<DailySleepLogEntity> findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/AvgSleepLog.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/AvgSleepLog.java
@@ -1,4 +1,4 @@
-package com.noom.interview.fullstack.sleep.entity;
+package com.noom.interview.fullstack.sleep.domain;
 
 import lombok.*;
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/DailySleepLog.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/DailySleepLog.java
@@ -1,4 +1,4 @@
-package com.noom.interview.fullstack.sleep.entity;
+package com.noom.interview.fullstack.sleep.domain;
 
 import lombok.*;
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/SleepQuality.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/SleepQuality.java
@@ -1,4 +1,4 @@
-package com.noom.interview.fullstack.sleep.entity;
+package com.noom.interview.fullstack.sleep.domain;
 
 import lombok.*;
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/GetLastMonth.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/GetLastMonth.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/GetLastSleep.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/GetLastSleep.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/SaveSleepLog.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/usecase/SaveSleepLog.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
 

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/controller/SleepLogControllerTest.java
@@ -2,7 +2,7 @@ package com.noom.interview.fullstack.sleep.controller;
 
 import com.fasterxml.jackson.databind.*;
 import com.noom.interview.fullstack.sleep.controller.dto.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import com.noom.interview.fullstack.sleep.usecase.*;
 import org.junit.jupiter.api.*;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProviderImplTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/db/DailySleepLogProviderImplTest.java
@@ -1,8 +1,8 @@
 package com.noom.interview.fullstack.sleep.db;
 
-import com.noom.interview.fullstack.sleep.db.datamapper.*;
+import com.noom.interview.fullstack.sleep.db.entity.*;
 import com.noom.interview.fullstack.sleep.db.repository.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -26,16 +26,16 @@ public class DailySleepLogProviderImplTest {
 
     @Test
     public void saveTest() {
-        when(sleepLogRepository.save(any(DailySleepLogDataMapper.class)))
+        when(sleepLogRepository.save(any(DailySleepLogEntity.class)))
             .thenReturn(DailySleepLogDataMapperFixture.defaultValues());
 
         DailySleepLog toSave = DailySleepLogFixture.defaultValuesNoId();
         DailySleepLog result = provider.save(toSave);
         Assertions.assertEquals(1L, result.getId());
 
-        ArgumentCaptor<DailySleepLogDataMapper> captor = ArgumentCaptor.forClass(DailySleepLogDataMapper.class);
+        ArgumentCaptor<DailySleepLogEntity> captor = ArgumentCaptor.forClass(DailySleepLogEntity.class);
         verify(sleepLogRepository, times(1)).save(captor.capture());
-        DailySleepLogDataMapper data = captor.getValue();
+        DailySleepLogEntity data = captor.getValue();
         Assertions.assertEquals(toSave.getSleepStart(), data.getSleepStart());
         Assertions.assertEquals(toSave.getSleepEnd(), data.getSleepEnd());
         Assertions.assertEquals(toSave.getSleepDuration(), data.getSleepDuration());
@@ -45,7 +45,7 @@ public class DailySleepLogProviderImplTest {
 
     @Test
     public void findByIntervalTest(){
-        DailySleepLogDataMapper resultFixture = DailySleepLogDataMapperFixture.defaultValues();
+        DailySleepLogEntity resultFixture = DailySleepLogDataMapperFixture.defaultValues();
         when(sleepLogRepository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(anyLong(), any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(List.of(resultFixture));
 
         List<DailySleepLog> result = provider.findByUserIdAndInterval(1L, LocalDateTime.now(), LocalDateTime.now());

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/db/repository/DailySleepLogRepositoryTests.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/db/repository/DailySleepLogRepositoryTests.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.db.repository;
 
-import com.noom.interview.fullstack.sleep.db.datamapper.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.db.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
@@ -25,18 +25,18 @@ public class DailySleepLogRepositoryTests {
     public void dataLoadTest() {
         Assertions.assertNotNull(repository);
 
-        List<DailySleepLogDataMapper> data = repository.findAll();
+        List<DailySleepLogEntity> data = repository.findAll();
         Assertions.assertEquals(3, data.size());
     }
 
     @Test
     public void insertDataTest() {
-        DailySleepLogDataMapper fixture = DailySleepLogDataMapperFixture.insertValues();
+        DailySleepLogEntity fixture = DailySleepLogDataMapperFixture.insertValues();
         repository.save(fixture);
 
-        List<DailySleepLogDataMapper> data = repository.findAll();
+        List<DailySleepLogEntity> data = repository.findAll();
         Assertions.assertEquals(4, data.size());
-        Optional<DailySleepLogDataMapper> insertedData = repository.findById(4L);
+        Optional<DailySleepLogEntity> insertedData = repository.findById(4L);
         Assertions.assertTrue(insertedData.isPresent());
         Assertions.assertEquals(fixture.getSleepDuration(), insertedData.get().getSleepDuration());
         Assertions.assertEquals(fixture.getSleepQuality(), insertedData.get().getSleepQuality());
@@ -45,7 +45,7 @@ public class DailySleepLogRepositoryTests {
 
     @Test
     public void findByUserIdAndIntervalTest() {
-        List<DailySleepLogDataMapper> data = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(2L,
+        List<DailySleepLogEntity> data = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(2L,
             LocalDateTime.of(2024, 1, 2, 0, 0),
             LocalDateTime.of(2024, 1, 2, 23, 59));
         Assertions.assertEquals(1, data.size());
@@ -54,7 +54,7 @@ public class DailySleepLogRepositoryTests {
 
     @Test
     public void findByUserIdAndIntervalTwoDaysTest() {
-        List<DailySleepLogDataMapper> data = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(2L,
+        List<DailySleepLogEntity> data = repository.findByUserIdAndSleepEndBetweenOrderBySleepEndDesc(2L,
             LocalDateTime.of(2024, 1, 2, 0, 0),
             LocalDateTime.of(2024, 1, 3, 23, 59));
         Assertions.assertEquals(2, data.size());

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/AvgSleepLogFixture.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/AvgSleepLogFixture.java
@@ -1,6 +1,6 @@
 package com.noom.interview.fullstack.sleep.fixtures;
 
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 
 import java.time.*;
 import java.util.*;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/DailySleepLogDataMapperFixture.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/DailySleepLogDataMapperFixture.java
@@ -1,15 +1,15 @@
 package com.noom.interview.fullstack.sleep.fixtures;
 
-import com.noom.interview.fullstack.sleep.db.datamapper.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.db.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 
 import java.time.*;
 
 public class DailySleepLogDataMapperFixture {
 
-    public static DailySleepLogDataMapper defaultValues() {
+    public static DailySleepLogEntity defaultValues() {
         DailySleepLog values = DailySleepLogFixture.defaultValues();
-        return DailySleepLogDataMapper.builder()
+        return DailySleepLogEntity.builder()
             .id(values.getId())
             .sleepStart(values.getSleepStart())
             .sleepEnd(values.getSleepEnd())
@@ -21,9 +21,9 @@ public class DailySleepLogDataMapperFixture {
             .build();
     }
 
-    public static DailySleepLogDataMapper insertValues() {
+    public static DailySleepLogEntity insertValues() {
         DailySleepLog values = DailySleepLogFixture.defaultValuesNoId();
-        return DailySleepLogDataMapper.builder()
+        return DailySleepLogEntity.builder()
             .sleepStart(values.getSleepStart())
             .sleepEnd(values.getSleepEnd())
             .userId(values.getUserId())

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/DailySleepLogFixture.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/fixtures/DailySleepLogFixture.java
@@ -1,6 +1,6 @@
 package com.noom.interview.fullstack.sleep.fixtures;
 
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 
 import java.time.*;
 import java.util.*;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/GetLasMonthTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/GetLasMonthTest.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import org.junit.jupiter.api.*;
 import org.mockito.*;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/GetLastSleepTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/GetLastSleepTest.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import org.junit.jupiter.api.*;
 import org.mockito.*;

--- a/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/SaveSleepLogTest.java
+++ b/sleep/src/test/java/com/noom/interview/fullstack/sleep/usecase/SaveSleepLogTest.java
@@ -1,7 +1,7 @@
 package com.noom.interview.fullstack.sleep.usecase;
 
 import com.noom.interview.fullstack.sleep.db.*;
-import com.noom.interview.fullstack.sleep.entity.*;
+import com.noom.interview.fullstack.sleep.domain.*;
 import com.noom.interview.fullstack.sleep.fixtures.*;
 import org.junit.jupiter.api.*;
 import org.mockito.*;


### PR DESCRIPTION
Renaming entity package do 'domain'
Renaming controller.datamapper to 'entity' to better reflects JPA